### PR TITLE
[BUG]: Trim page title to match

### DIFF
--- a/src/layouts/Layout/CHeader/CHeader.tsx
+++ b/src/layouts/Layout/CHeader/CHeader.tsx
@@ -277,7 +277,8 @@ const Navbar: React.FC<CHeaderProps> = ({allContentfulHeader, allContentfulResou
 		const clickHandlers = [];
 
 		allLi.forEach(li => {
-			const [currentPage] = pages.filter(page => page.title === li.innerText);
+			const titleToMatch = li.innerText.trim();
+			const [currentPage] = pages.filter(page => page.title === titleToMatch);
 
 			// Initial set active
 			if (


### PR DESCRIPTION
## Description
This PR includes hotfix for page links not working in safari.

## Summary of changes
- Trim page title string to match