### PR TITLE
[HOTFIX]: Replace description as plain string

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -76,7 +76,6 @@ status = 200
 # source repositories.
 [context.deploy-preview.environment]
   NODE_ENV = "development"
-  CONTENTFUL_ENVIRONMENT = "develop"
 
 # Dev context: environment variables set here 
 # are available for local development environments 

--- a/netlify.toml
+++ b/netlify.toml
@@ -78,12 +78,6 @@ status = 200
   NODE_ENV = "development"
   CONTENTFUL_ENVIRONMENT = "develop"
 
-# Branch Deploy context: all deploys that are not from
-# a pull/merge request or from the Production branch
-# will inherit these settings.
-[context.branch-deploy.environment]
-  NODE_ENV = "development"
-
 # Dev context: environment variables set here 
 # are available for local development environments 
 # run using Netlify Dev. These values can be 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 	},
 	"dependencies": {
 		"@aaronhayes/react-use-hubspot-form": "^2.1.1",
-		"@contentful/rich-text-plain-text-renderer": "^15.12.1",
+		"@contentful/rich-text-plain-text-renderer": "^16.0.2",
 		"@emotion/react": "^11.9.3",
 		"@fontsource/lato": "^4.5.9",
 		"@fontsource/raleway": "^4.5.10",

--- a/src/components/common/Resources/ResourceCard.tsx
+++ b/src/components/common/Resources/ResourceCard.tsx
@@ -1,13 +1,12 @@
 import {Paper, Title, Divider, Button, Text, createStyles, Grid, Box, Anchor, Group} from '@mantine/core';
 import classNames from 'classnames';
+import React from 'react';
 import type {FC} from 'react';
 import {Link} from 'gatsby';
-import React from 'react';
 import type {TResource} from 'types/resource';
 import {getLink} from 'utils/getLink';
 import ImageContainer from '../Container/ImageContainer';
 import Asset from '../Asset/Asset';
-import {BLOCKS, MARKS, INLINES} from '@contentful/rich-text-types';
 import {getDescriptionFromRichtext} from 'utils/getDescription';
 
 type ResourceCardProps = {
@@ -49,42 +48,6 @@ export const ResourceCard: FC<ResourceCardProps> = ({resource}) => {
 
 	const {classes} = useStyles();
 	const {link, isExternal} = getLink(resource);
-
-	const options = {
-		renderMark: {
-			[MARKS.BOLD]: text => text as string,
-			[MARKS.ITALIC]: text => text as string,
-		},
-		renderNode: {
-			[BLOCKS.PARAGRAPH](node, children) {
-				return children as string;
-			},
-			[BLOCKS.UL_LIST](node, children) {
-				return children as string;
-			},
-			[BLOCKS.OL_LIST](node, children) {
-				return children as string;
-			},
-			[BLOCKS.LIST_ITEM](node, children) {
-				return children as string;
-			},
-			[INLINES.HYPERLINK](node, children) {
-				return children as string;
-			},
-			[BLOCKS.HEADING_1](node, children) {
-				return children as string;
-			},
-			[BLOCKS.HEADING_2](node, children) {
-				return children as string;
-			},
-			[BLOCKS.HEADING_3](node, children) {
-				return children as string;
-			},
-			[BLOCKS.HEADING_4](node, children) {
-				return children as string;
-			},
-		},
-	};
 
 	return (
 		<Paper radius={0} className={classNames(classes.card)}>

--- a/src/components/common/Resources/ResourceCard.tsx
+++ b/src/components/common/Resources/ResourceCard.tsx
@@ -1,16 +1,14 @@
-import {Paper, Title, Divider, Button, Text, createStyles, Grid, Box, Anchor, Group, Center} from '@mantine/core';
+import {Paper, Title, Divider, Button, Text, createStyles, Grid, Box, Anchor, Group} from '@mantine/core';
 import classNames from 'classnames';
-import {GatsbyImage, getImage} from 'gatsby-plugin-image';
 import type {FC} from 'react';
-import type {TAsset} from 'types/asset';
 import {Link} from 'gatsby';
 import React from 'react';
-import type {TLink, TResource} from 'types/resource';
+import type {TResource} from 'types/resource';
 import {getLink} from 'utils/getLink';
-import {renderRichText} from 'gatsby-source-contentful/rich-text';
 import ImageContainer from '../Container/ImageContainer';
 import Asset from '../Asset/Asset';
 import {BLOCKS, MARKS, INLINES} from '@contentful/rich-text-types';
+import {getDescriptionFromRichtext} from 'utils/getDescription';
 
 type ResourceCardProps = {
 	sectionHeader: string;
@@ -54,36 +52,36 @@ export const ResourceCard: FC<ResourceCardProps> = ({resource}) => {
 
 	const options = {
 		renderMark: {
-			[MARKS.BOLD]: text => <>{text}</>,
-			[MARKS.ITALIC]: text => <>{text}</>,
+			[MARKS.BOLD]: text => text as string,
+			[MARKS.ITALIC]: text => text as string,
 		},
 		renderNode: {
 			[BLOCKS.PARAGRAPH](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 			[BLOCKS.UL_LIST](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 			[BLOCKS.OL_LIST](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 			[BLOCKS.LIST_ITEM](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 			[INLINES.HYPERLINK](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 			[BLOCKS.HEADING_1](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 			[BLOCKS.HEADING_2](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 			[BLOCKS.HEADING_3](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 			[BLOCKS.HEADING_4](node, children) {
-				return <>{children}</>;
+				return children as string;
 			},
 		},
 	};
@@ -120,7 +118,7 @@ export const ResourceCard: FC<ResourceCardProps> = ({resource}) => {
 						<Divider variant='dashed' size={1} style={{maxWidth: 404}} my={10} />
 						{resource.body && (
 							<Text size={18} mt='sm' mb={20} lineClamp={2}>
-								{renderRichText(resource.body, options)}
+								{getDescriptionFromRichtext(resource.body.raw)}
 							</Text>
 						)}
 						{resource.buttonText && (

--- a/src/utils/getDescription.ts
+++ b/src/utils/getDescription.ts
@@ -1,0 +1,21 @@
+import {documentToPlainTextString} from '@contentful/rich-text-plain-text-renderer';
+import type {Document} from '@contentful/rich-text-types';
+
+/**
+
+Given a raw rich text field, this function extracts the first three sentences as a plain text string.
+
+@param {string} rawRichTextField - The raw rich text field to extract the description from.
+
+@return {string} - The first three sentences of the rich text field as a plain text string.
+*/
+export const getDescriptionFromRichtext = (rawRichTextField: string): string => {
+	const document: Document = JSON.parse(rawRichTextField) as Document;
+
+	const plainText = documentToPlainTextString(document);
+	const re = /(?<=[.!?])\s/g;
+	const sentences = plainText.split(re);
+	const firstThreeSentences = sentences.slice(0, 3).join(' ');
+
+	return firstThreeSentences;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1075,12 +1075,12 @@
   resolved "https://registry.npmjs.org/@builder.io/partytown/-/partytown-0.5.4.tgz"
   integrity sha512-qnikpQgi30AS01aFlNQV6l8/qdZIcP76mp90ti+u4rucXHsn4afSKivQXApqxvrQG9+Ibv45STyvHizvxef/7A==
 
-"@contentful/rich-text-plain-text-renderer@^15.12.1":
-  version "15.12.1"
-  resolved "https://registry.npmjs.org/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-15.12.1.tgz"
-  integrity sha512-0pDLs4V1dhK98yoIFq8e16Ey54uyAPLKeqMtry3db4X0zEuA/+6CEetoyEdJrySAaCkfB7+Y6n4vKMFUSPHs3Q==
+"@contentful/rich-text-plain-text-renderer@^16.0.2":
+  version "16.0.2"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-plain-text-renderer/-/rich-text-plain-text-renderer-16.0.2.tgz#8e7cd525ed7b5fc623901291c45ec401e4e2b31b"
+  integrity sha512-8GDARwU0X8XZU8Vor7N0NRqyHeYp1/RHOhS2qhm0kDJGRaPocs1tL6nzHXjSnmGuTgH0NCk4QreAZltakIgbzQ==
   dependencies:
-    "@contentful/rich-text-types" "^15.12.1"
+    "@contentful/rich-text-types" "^16.0.2"
 
 "@contentful/rich-text-react-renderer@^15.12.1":
   version "15.12.1"
@@ -1093,6 +1093,11 @@
   version "15.13.2"
   resolved "https://registry.npmjs.org/@contentful/rich-text-types/-/rich-text-types-15.13.2.tgz"
   integrity sha512-cnVvJjRQ414rprnoMLR/S+18a7Hjp3dR4WhiQ/A6W/LSS5FDx1AbiDZACjIEaQEk5L6FX0oBHanIIbAUTA5YJw==
+
+"@contentful/rich-text-types@^16.0.2":
+  version "16.0.2"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-16.0.2.tgz#779bc76b5159152b3a9e908e6a04cb9342faa9b1"
+  integrity sha512-ovbmCKQjlyGek4NuABoqDesC3FBV3e5jPMMdtT2mpOy9ia31MKO0NSFMRGZu7Q+veZzmDMja8S1i/XeFCUT9Pw==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"


### PR DESCRIPTION
## Description
This PR includes hotfix updates for this [ticket](https://app.asana.com/0/0/1203787109002704/f)

## Summary of changes
- Update description to be used as plain string
- Add util function to convert raw string of richtext field to plain string from the first 3 sentences