### PR TITLE
fix: use gatsby image in the leadership page

### DIFF
--- a/src/layouts/Layout/CFooter/desktopFooter.module.css
+++ b/src/layouts/Layout/CFooter/desktopFooter.module.css
@@ -76,6 +76,14 @@
 
 .headerCTA {
 	margin-right: 0px !important;
+
+	div:first-child{
+		width: 100%;
+
+		span:first-child{
+			width: 100%;;
+		}
+	}
 }
 
 .patientLoginButtonMobile:hover {

--- a/src/templates/leadership.tsx
+++ b/src/templates/leadership.tsx
@@ -20,7 +20,10 @@ import { BLOCKS, INLINES } from "@contentful/rich-text-types";
 import { Options } from "@contentful/rich-text-react-renderer";
 import cx from "clsx";
 import { renderRichText } from "gatsby-source-contentful/rich-text";
+
 import { ELinkedinIcon } from "components/common/Buttons/SocialButtons/ELinkedInIcon";
+import ImageContainer from "components/common/Container/ImageContainer";
+import Asset from "components/common/Asset/Asset";
 
 type LeadershipProps = {
   data: { contentfulPage: ContentfulPage };
@@ -62,8 +65,9 @@ const ECard = ({ reference }: any) => {
         width: "500px",
       }}
     >
-      <Image src={media.media.file.url} alt={media.media.title} />
-
+      <ImageContainer fluid contain card>
+        <Asset asset={media.media} />
+      </ImageContainer>
       <div
         style={{
           display: "flex",


### PR DESCRIPTION
Parent Ticket:
https://phildotus.atlassian.net/browse/MRTG-1213

<img width="2425" height="1154" alt="image" src="https://github.com/user-attachments/assets/6292f809-82e7-498f-bc72-a8c280c45bed" />

<img width="2369" height="1200" alt="image" src="https://github.com/user-attachments/assets/e6a9c9fa-10da-4446-bb13-d75826149fdf" />
