### PR TITLE
(Local:Solution) Error in Gatsby-browser (module not found): update the pdfjs url

### DIFF
--- a/gatsby-browser.tsx
+++ b/gatsby-browser.tsx
@@ -26,5 +26,6 @@ export const wrapPageElement = ({element}) => {
 	);
 };
 
-pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.js', import.meta.url).toString();
+// pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.min.js', import.meta.url).toString();
+pdfjs.GlobalWorkerOptions.workerSrc = new URL('pdfjs-dist/build/pdf.worker.mjs', import.meta.url).toString();
 


### PR DESCRIPTION


<img width="1967" height="1267" alt="image" src="https://github.com/user-attachments/assets/b15b061f-a8e3-4bc0-8fa6-b131f4274e55" />


if error encouter use this code