### PR TITLE
[REVIEW] add redirect logic to enroll landing page from /sign-up/{token} url

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -58,6 +58,11 @@ from = "/e/*"
 to = "https://enroll.phil.us/landing/:splat"
 status = 302
 
+[[redirects]]
+from = "/sign-up/*"
+to = "https://enroll.phil.us/landing/:splat"
+status = 302
+
 # /md/enroll redirection
 [[redirects]]
 from = "/md/enroll"
@@ -86,7 +91,17 @@ to = "https://enroll.stage.phil.us/landing/:splat"
 status = 302
 
 [[redirects]]
+from = "/stage/sign-up/*"
+to = "https://enroll.stage.phil.us/landing/:splat"
+status = 302
+
+[[redirects]]
 from = "/dev/e/*"
+to = "https://enroll.dev.phil.us/landing/:splat"
+status = 302
+
+[[redirects]]
+from = "/dev/sign-up/*"
 to = "https://enroll.dev.phil.us/landing/:splat"
 status = 302
 


### PR DESCRIPTION
Jira ticket: https://phildotus.atlassian.net/browse/PEXP-864

Background: the existing behavior for sign up links is we send users a shortened url in the format "phil.us/e/{token}". The existing redirection logic in the platform redirects this URL to enroll.phil.us/landing/{token}. In the jira ticket, we are adding an A/B test to send some enrollment URLs in the format "philrx.com/sign-up/{token}". The current logic redirects from philrx.com to phil.us but does not handle the redirection from /sign-up. This PR adds that redirection logic

Changes:
- add prod redirection logic from /sign-up/* to enroll.phil.us/landing/:splat
- add stage redirection logic from /stage/sign-up/* to enroll.stage.phil.us/landing/:splat
- add dev redirection logic from /dev/sign-up/* to enroll.dev.phil.us/landing/:splat