### PR TITLE
PEXP-927: fix redirection logic

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -112,17 +112,17 @@ status = 302
 
 # phil-me redirection
 [[redirects]]
-from = "/checkout/*"
+from = "https://philrx.com/checkout/*"
 to = "https://my.phil.us/gpa/:splat"
 status = 302
 
 [[redirects]]
-from = "/stage/checkout/*"
+from = "https://philrx.com/stage/checkout/*"
 to = "https://my.stage.phil.us/gpa/:splat"
 status = 302
 
 [[redirects]]
-from = "/dev/checkout/*"
+from = "https://philrx.com/dev/checkout/*"
 to = "https://my.dev.phil.us/gpa/:splat"
 status = 302
 


### PR DESCRIPTION
## Purpose of the PR
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix 
- [ ] UI/UX improvement

> Update payment approval link to philrx domain

## JIRA
- https://phildotus.atlassian.net/browse/PEXP-927

## Related PRs
- https://github.com/phil-inc/phil-us-contentful/pull/557

## Work Description
- [Looker](https://usephil.looker.com/explore/phil_reporting/fct_ror_events?qid=bMKqw5rJlk8wMk0eb0opi3&toggle=fil) - of orders created in the past 6 months, payment approval link had a 91.59% click through rate. Since we saw success with updating enrollment link to [philrx.com](http://philrx.com/) domain, we want to update the payment approval link to have [philrx.com](http://philrx.com/) domain as well.

