### PR TITLE
SEO reducing numbre of H1 tags

### DIFF
--- a/src/components/common/RichTextRenderer/RichTextRenderer.tsx
+++ b/src/components/common/RichTextRenderer/RichTextRenderer.tsx
@@ -170,7 +170,7 @@ const RichTextRenderer = ({
       [BLOCKS.HEADING_1](node, children: React.ReactNode) {
         return (
           <Title
-            order={1}
+            order={2}
             data-context={context.title}
           >
             {children}

--- a/src/components/section/BasicSection/BasicSection.tsx
+++ b/src/components/section/BasicSection/BasicSection.tsx
@@ -289,7 +289,7 @@ const BasicSection: React.FC<BasicSectionProps> = ({
 
         return (
           <Title
-            order={1}
+            order={2}
             data-context={context.title}
             className={classes.title}
           >

--- a/src/components/section/ReferencedSection/ReferencedSection.tsx
+++ b/src/components/section/ReferencedSection/ReferencedSection.tsx
@@ -207,7 +207,7 @@ const ReferencedSection: React.FC<ReferencedSectionProps> = ({
     sectionContent = (
       <div className={classes.commitmentCard}>
         <div className={classes.commitmentCardLeftSection}>
-          <h1 style={{fontSize: "40px", fontWeight: 700}}>{section.header}</h1>
+          <h2 style={{fontSize: "40px", fontWeight: 700}}>{section.header}</h2>
           <p style={{fontSize: "18px", fontWeight: 400}}>{section.subHeading?.subHeading}</p>
         </div>
         


### PR DESCRIPTION
15 H1 tags on a single page — should be exactly 1. "Pharma", "Patients", "Providers", stat numbers (90%, 85%, 2x+, 3x), "Leadership", "Careers" etc. are all incorrectly tagged as H1s. Only "Medication Access, Simplified" should remain as H1.

### JIRA
<!-- Replace this line with Ticket link -->

## Description
<!-- Please include a summary of the changes and the related issue. -->

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
