### PR TITLE
SEO reducing number of H1 tags

### DIFF
--- a/src/components/sectionInColumn/basicSectionColumn/BasicSectionColumn.tsx
+++ b/src/components/sectionInColumn/basicSectionColumn/BasicSectionColumn.tsx
@@ -227,7 +227,7 @@ const BasicSectionColumn = ({ section, index = 0 }: Props) => {
       [BLOCKS.HEADING_1](node, children) {
         return (
           <Title
-            order={1}
+            order={2}
             data-context={context.title}
             className={classes.title}
           >


### PR DESCRIPTION
There should be 1 H1 tag per page

### JIRA
<!-- Replace this line with Ticket link -->

## Description
<!-- Please include a summary of the changes and the related issue. -->

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
