### PR TITLE
feat: implement download token system for gated reports

### DIFF
--- a/src/api/download-report/[id].ts
+++ b/src/api/download-report/[id].ts
@@ -6,11 +6,8 @@ import { verifyDownloadToken } from "../../utils/downloadToken";
 
 type ContentfulAsset = {
   fields?: {
-    title?: string;
     file?: {
       url?: string;
-      fileName?: string;
-      contentType?: string;
     };
   };
 };
@@ -64,34 +61,10 @@ const handler = async (
   }
 
   const absolute = fileUrl.startsWith("//") ? `https:${fileUrl}` : fileUrl;
-  const upstream = await fetch(absolute);
-  if (!upstream.ok || !upstream.body) {
-    res.status(502).json({ error: "upstream_failed" });
-    return;
-  }
 
-  const contentType =
-    upstream.headers.get("content-type") ||
-    asset?.fields?.file?.contentType ||
-    "application/pdf";
-  const fileName =
-    asset?.fields?.file?.fileName ||
-    asset?.fields?.title ||
-    `${assetId}.pdf`;
-
-  res.setHeader("Content-Type", contentType);
-  res.setHeader(
-    "Content-Disposition",
-    `inline; filename="${fileName.replace(/"/g, "")}"`,
-  );
   res.setHeader("X-Robots-Tag", "noindex, nofollow");
   res.setHeader("Cache-Control", "private, no-store");
-
-  const contentLength = upstream.headers.get("content-length");
-  if (contentLength) res.setHeader("Content-Length", contentLength);
-
-  const buf = Buffer.from(await upstream.arrayBuffer());
-  res.status(200).send(buf);
+  res.redirect(absolute);
 };
 
 export default handler;

--- a/src/api/download-report/[id].ts
+++ b/src/api/download-report/[id].ts
@@ -1,0 +1,97 @@
+import {
+  type GatsbyFunctionRequest,
+  type GatsbyFunctionResponse,
+} from "gatsby";
+import { verifyDownloadToken } from "../../utils/downloadToken";
+
+type ContentfulAsset = {
+  fields?: {
+    title?: string;
+    file?: {
+      url?: string;
+      fileName?: string;
+      contentType?: string;
+    };
+  };
+};
+
+async function fetchContentfulAsset(
+  assetId: string,
+): Promise<ContentfulAsset | null> {
+  const space = process.env.CONTENTFUL_SPACE_ID;
+  const env = process.env.CONTENTFUL_ENVIRONMENT || "master";
+  const token = process.env.CONTENTFUL_ACCESS_TOKEN;
+  if (!space || !token) return null;
+
+  const url = `https://cdn.contentful.com/spaces/${space}/environments/${env}/assets/${encodeURIComponent(
+    assetId,
+  )}?access_token=${token}`;
+
+  const res = await fetch(url);
+  if (!res.ok) return null;
+  return (await res.json()) as ContentfulAsset;
+}
+
+const handler = async (
+  req: GatsbyFunctionRequest,
+  res: GatsbyFunctionResponse,
+) => {
+  const secret = process.env.DOWNLOAD_TOKEN_SECRET;
+  if (!secret) {
+    res.status(500).json({ error: "server_not_configured" });
+    return;
+  }
+
+  const assetId = req.params.id;
+  const token =
+    typeof req.query.token === "string" ? req.query.token : undefined;
+  if (!assetId || !token) {
+    res.status(401).json({ error: "missing_token" });
+    return;
+  }
+
+  const payload = verifyDownloadToken(token, secret);
+  if (!payload || payload.assetId !== assetId) {
+    res.status(403).json({ error: "invalid_token" });
+    return;
+  }
+
+  const asset = await fetchContentfulAsset(assetId);
+  const fileUrl = asset?.fields?.file?.url;
+  if (!fileUrl) {
+    res.status(404).json({ error: "asset_not_found" });
+    return;
+  }
+
+  const absolute = fileUrl.startsWith("//") ? `https:${fileUrl}` : fileUrl;
+  const upstream = await fetch(absolute);
+  if (!upstream.ok || !upstream.body) {
+    res.status(502).json({ error: "upstream_failed" });
+    return;
+  }
+
+  const contentType =
+    upstream.headers.get("content-type") ||
+    asset?.fields?.file?.contentType ||
+    "application/pdf";
+  const fileName =
+    asset?.fields?.file?.fileName ||
+    asset?.fields?.title ||
+    `${assetId}.pdf`;
+
+  res.setHeader("Content-Type", contentType);
+  res.setHeader(
+    "Content-Disposition",
+    `inline; filename="${fileName.replace(/"/g, "")}"`,
+  );
+  res.setHeader("X-Robots-Tag", "noindex, nofollow");
+  res.setHeader("Cache-Control", "private, no-store");
+
+  const contentLength = upstream.headers.get("content-length");
+  if (contentLength) res.setHeader("Content-Length", contentLength);
+
+  const buf = Buffer.from(await upstream.arrayBuffer());
+  res.status(200).send(buf);
+};
+
+export default handler;

--- a/src/api/issue-download-token.ts
+++ b/src/api/issue-download-token.ts
@@ -1,0 +1,58 @@
+import {
+  type GatsbyFunctionRequest,
+  type GatsbyFunctionResponse,
+} from "gatsby";
+import { signDownloadToken } from "../utils/downloadToken";
+
+const TOKEN_TTL_SECONDS = 10 * 60;
+
+const ALLOWED_ORIGINS = new Set([
+  "https://www.phil.us",
+  "https://phil.us",
+  "http://localhost:3000",
+  "http://localhost:9000",
+]);
+
+type Body = {
+  assetId?: string;
+};
+
+const handler = async (
+  req: GatsbyFunctionRequest,
+  res: GatsbyFunctionResponse,
+) => {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "method_not_allowed" });
+    return;
+  }
+
+  const origin = req.headers.origin;
+  if (origin && !ALLOWED_ORIGINS.has(origin)) {
+    res.status(403).json({ error: "forbidden_origin" });
+    return;
+  }
+
+  const secret = process.env.DOWNLOAD_TOKEN_SECRET;
+  if (!secret) {
+    res.status(500).json({ error: "server_not_configured" });
+    return;
+  }
+
+  const { assetId } = (req.body ?? {}) as Body;
+  if (!assetId) {
+    res.status(400).json({ error: "missing_asset_id" });
+    return;
+  }
+
+  const token = signDownloadToken(
+    {
+      assetId,
+      exp: Math.floor(Date.now() / 1000) + TOKEN_TTL_SECONDS,
+    },
+    secret,
+  );
+
+  res.status(200).json({ token });
+};
+
+export default handler;

--- a/src/api/issue-download-token.ts
+++ b/src/api/issue-download-token.ts
@@ -6,12 +6,15 @@ import { signDownloadToken } from "../utils/downloadToken";
 
 const TOKEN_TTL_SECONDS = 10 * 60;
 
-const ALLOWED_ORIGINS = new Set([
-  "https://www.phil.us",
-  "https://phil.us",
-  "http://localhost:3000",
-  "http://localhost:9000",
-]);
+const ALLOWED_ORIGIN_PATTERNS = [
+  /^https:\/\/(www\.)?phil\.us$/,
+  /^https:\/\/[a-z0-9-]+--phil-us\.netlify\.app$/,
+  /^http:\/\/localhost:\d+$/,
+];
+
+function isAllowedOrigin(origin: string): boolean {
+  return ALLOWED_ORIGIN_PATTERNS.some((pattern) => pattern.test(origin));
+}
 
 type Body = {
   assetId?: string;
@@ -27,7 +30,7 @@ const handler = async (
   }
 
   const origin = req.headers.origin;
-  if (origin && !ALLOWED_ORIGINS.has(origin)) {
+  if (origin && !isAllowedOrigin(origin)) {
     res.status(403).json({ error: "forbidden_origin" });
     return;
   }

--- a/src/components/common/GatedReportForm/GatedReportForm.tsx
+++ b/src/components/common/GatedReportForm/GatedReportForm.tsx
@@ -6,11 +6,11 @@ import { getHubspotFormDetails } from "utils/utils";
 
 import * as classes from "./GatedReportForm.module.css";
 
-const REPORT_FORM_SUBMITTED_KEY = "researchReportFormSubmitted";
+const SUBMITTED_KEY = "researchReportFormSubmitted";
 
 type GatedReportFormProps = {
   column: any;
-  fileUrl?: string;
+  assetId?: string;
   heading?: string;
   subHeadingText?: string;
   sectionEyebrow?: string;
@@ -18,29 +18,68 @@ type GatedReportFormProps = {
 
 export function GatedReportForm({
   column,
-  fileUrl,
+  assetId,
   heading,
   subHeadingText,
   sectionEyebrow = "WHAT'S INSIDE",
 }: GatedReportFormProps) {
   const [isSubmitted, setIsSubmitted] = React.useState(false);
+  const [downloadToken, setDownloadToken] = React.useState<string | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const inFlightRef = React.useRef(false);
 
   const { formId, portalId } = getHubspotFormDetails(
     column?.raw ? { raw: column.raw } : undefined
   );
 
+  // On mount: restore submitted state only — don't auto-request token
   React.useEffect(() => {
-    if (sessionStorage.getItem(REPORT_FORM_SUBMITTED_KEY) === "true") {
+    if (sessionStorage.getItem(SUBMITTED_KEY) === "true") {
       setIsSubmitted(true);
     }
   }, []);
 
+  const requestDownloadToken = React.useCallback(async () => {
+    if (!assetId) {
+      setError("Missing asset reference. Please refresh and try again.");
+      return;
+    }
+    setError(null);
+    try {
+      const res = await fetch("/api/issue-download-token", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ assetId }),
+      });
+      if (!res.ok) throw new Error(`status ${res.status}`);
+      const { token } = (await res.json()) as { token?: string };
+      if (!token) throw new Error("no_token");
+      setDownloadToken(token);
+    } catch {
+      setError("We couldn't generate your download link. Please try again.");
+    }
+  }, [assetId]);
+
   const handleFormSubmit = () => {
-    sessionStorage.setItem(REPORT_FORM_SUBMITTED_KEY, "true");
+    if (inFlightRef.current) return;
+    inFlightRef.current = true;
+    sessionStorage.setItem(SUBMITTED_KEY, "true");
     setIsSubmitted(true);
+    void requestDownloadToken().finally(() => {
+      inFlightRef.current = false;
+    });
+  };
+
+  const handleGetLink = () => {
+    void requestDownloadToken();
   };
 
   if (!formId || !portalId) return null;
+
+  const downloadHref =
+    assetId && downloadToken
+      ? `/api/download-report/${assetId}?token=${encodeURIComponent(downloadToken)}`
+      : null;
 
   return (
     <Box className={classes.form}>
@@ -61,13 +100,39 @@ export function GatedReportForm({
               {subHeadingText}
             </Text>
           )}
-          {fileUrl && (
-            <Anchor href={fileUrl} target="_blank" referrerPolicy="no-referrer">
+
+          {downloadHref ? (
+            <Anchor
+              href={downloadHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              referrerPolicy="no-referrer"
+            >
               <Button variant="philDefault" w="100%" mb="md">
                 Access Report
               </Button>
             </Anchor>
+          ) : (
+            <>
+              <Text fz="sm" c="dimmed" mb="sm">
+                You&apos;ve already submitted. Click below to get your download link.
+              </Text>
+              <Button
+                variant="philDefault"
+                w="100%"
+                mb="md"
+                onClick={handleGetLink}
+              >
+                Get Download Link
+              </Button>
+              {error && (
+                <Text c="red" fz="sm" mb="sm">
+                  {error}
+                </Text>
+              )}
+            </>
           )}
+
           <Text className={classes.submittedPrivacy} component="p">
             By submitting this form, you agree to PHIL&apos;s{" "}
             <Anchor
@@ -96,6 +161,11 @@ export function GatedReportForm({
             formMinHeight="200px"
             callbackFn={handleFormSubmit}
           />
+          {error && (
+            <Text c="red" fz="sm" mt="sm">
+              {error}
+            </Text>
+          )}
         </>
       )}
     </Box>

--- a/src/components/text-text-columns/index.tsx
+++ b/src/components/text-text-columns/index.tsx
@@ -194,7 +194,7 @@ const TextAndTextColumns = ({ data, sectionIndex = 0 }: TextAndTextColumnsProps)
   const context = useContext(PageContext);
 
   const { heading, subHeadingText, leftColumn, rightColumn, addBorder, files, sectionName } = data;
-  const fileUrl = files?.[0]?.file?.url ?? files?.[0]?.url;
+  const assetId = files?.[0]?.contentful_id;
 
   const { formId, portalId } = getHubspotFormDetails(
     rightColumn?.raw ? { raw: rightColumn.raw } : undefined
@@ -249,7 +249,7 @@ const TextAndTextColumns = ({ data, sectionIndex = 0 }: TextAndTextColumnsProps)
             {hasGatedForm ? (
               <GatedReportForm
                 column={rightColumn}
-                fileUrl={fileUrl}
+                assetId={assetId}
                 heading={heading}
                 subHeadingText={subHeadingText}
                 sectionEyebrow={sectionName ?? "What's Inside"}

--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -709,6 +709,7 @@ export const query = graphql`
             name
           }
           files {
+            contentful_id
             url
             file {
               url

--- a/src/utils/downloadToken.ts
+++ b/src/utils/downloadToken.ts
@@ -1,0 +1,60 @@
+import crypto from "crypto";
+
+export type DownloadTokenPayload = {
+  assetId: string;
+  exp: number;
+};
+
+const b64url = (buf: Buffer) =>
+  buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+
+const b64urlDecode = (s: string) =>
+  Buffer.from(s.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+
+export function signDownloadToken(
+  payload: DownloadTokenPayload,
+  secret: string,
+): string {
+  const body = b64url(Buffer.from(JSON.stringify(payload)));
+  const sig = b64url(
+    crypto.createHmac("sha256", secret).update(body).digest(),
+  );
+  return `${body}.${sig}`;
+}
+
+export function verifyDownloadToken(
+  token: string,
+  secret: string,
+): DownloadTokenPayload | null {
+  const parts = token.split(".");
+  if (parts.length !== 2) return null;
+  const [body, sig] = parts;
+
+  const expected = b64url(
+    crypto.createHmac("sha256", secret).update(body).digest(),
+  );
+  const a = Buffer.from(sig);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return null;
+
+  let payload: DownloadTokenPayload;
+  try {
+    payload = JSON.parse(b64urlDecode(body).toString("utf8"));
+  } catch {
+    return null;
+  }
+
+  if (
+    typeof payload.assetId !== "string" ||
+    typeof payload.exp !== "number" ||
+    payload.exp < Math.floor(Date.now() / 1000)
+  ) {
+    return null;
+  }
+
+  return payload;
+}


### PR DESCRIPTION
- Added API endpoint to issue download tokens for assets, ensuring secure access.
- Created a new API endpoint to fetch reports using the download token, validating the token and asset ID.
- Updated GatedReportForm component to request and handle download tokens, improving user experience for accessing reports.
- Modified related components to utilize asset IDs instead of file URLs for better integration with the new token system.

### JIRA
<!-- Replace this line with Ticket link -->

## Description
Even though the form is gated in hcp-research and dtp-research in Google Search It is easily accessible and downloadable.

## Related PRs
<!-- Link the issues this PR closes or relates to -->
https://github.com/phil-inc/phil-us-contentful/pull/719

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
