### PR TITLE
React Hydration Fix

### DIFF
--- a/src/layouts/Layout/CHeader/CDrawer.tsx
+++ b/src/layouts/Layout/CHeader/CDrawer.tsx
@@ -10,10 +10,11 @@ import {
   List,
   Badge,
 } from "@mantine/core";
-import { IconChevronDown } from "@tabler/icons";
+import { IconChevronDown } from "@tabler/icons-react";
 import Asset from "components/common/Asset/Asset";
 import { Link } from "gatsby";
 import React from "react";
+import { useLocation } from "@reach/router";
 import { getPathForSectionAndPage } from "utils/links";
 import { Link as ScrollToElement } from "react-scroll";
 import HeaderContext from "contexts/HeaderProvider";
@@ -31,6 +32,7 @@ import * as classes from "./drawer.module.css";
 const CDrawer: React.FC = () => {
   const { header, isDrawer, pages, toggleDrawer, buttons } =
     React.useContext(HeaderContext);
+  const location = useLocation();
 
   const buttonConfig = {
     primary: { variant: "header-primary", size: "md", uppercase: true },
@@ -156,7 +158,7 @@ const CDrawer: React.FC = () => {
                           <List.Item py="xs">
                             {/* All sections except for the first */}
 
-                            {page.title === document.title &&
+                            {location.pathname.includes(`/${page.slug}`) &&
                             page.title !== INSIGHTS ? (
                               <ScrollToElement
                                 to={path}

--- a/src/layouts/Layout/CInfoBar/CInfoBar.tsx
+++ b/src/layouts/Layout/CInfoBar/CInfoBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { graphql, StaticQuery } from "gatsby";
 
 import { TopInfoBarNode } from "types/infoBar";
@@ -18,14 +18,14 @@ const TopInfoBar: React.FC<AllContentfulTopInfoBarQuery> = ({
   allContentfulTopInfoBar,
 }) => {
   const [topAnnoucement] = allContentfulTopInfoBar?.nodes || [];
-  const [canShowInfoBar, setCanShowInforBar] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
+  const [canShowInfoBar, setCanShowInforBar] = useState<boolean>(false);
 
-    return (
+  useEffect(() => {
+    setCanShowInforBar(
       Boolean(topAnnoucement?.reference) &&
-      sessionStorage.getItem(SHOW_INFOBAR) !== FALSE_STRING
+        sessionStorage.getItem(SHOW_INFOBAR) !== FALSE_STRING,
     );
-  });
+  }, [topAnnoucement?.reference]);
   
   const displayableSlug =
     topAnnoucement?.pagesToShowInfoBar?.map((page) => page?.slug) ?? [];


### PR DESCRIPTION
The site fires 15× React Error #418 (SSR/client HTML mismatch) and 1× Error #423 (hydration failure) on every load. This means React is silently re-rendering the entire page on the client after the server-rendered version comes down — causing unnecessary layout shifts, wasting CPU cycles, and hurting your Core Web Vitals (CLS)

### JIRA
<!-- Replace this line with Ticket link -->

## Description
<!-- Please include a summary of the changes and the related issue. -->

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
