### PR TITLE
Reducing unused JavaScript & CSS

### DIFF
--- a/src/assets/css/index.css
+++ b/src/assets/css/index.css
@@ -2,7 +2,6 @@
 @import "anchor.css";
 @import "hubspot-form.css";
 @import "mantine-accordion-override.css";
-@import url("https://cdn.jsdelivr.net/npm/@tabler/icons-webfont@latest/dist/tabler-icons.min.css");
 
 :root {
   --navbar-height: 90px;
@@ -98,8 +97,7 @@
       }
 
       &:after {
-        content: "\ea1f";
-        font-family: "tabler-icons";
+        content: "→";
         display: inline-block;
         vertical-align: middle;
         margin-left: 4px;

--- a/src/components/LeaderProfileCard/LeaderProfileCard.tsx
+++ b/src/components/LeaderProfileCard/LeaderProfileCard.tsx
@@ -1,6 +1,6 @@
 import { Anchor, Box, Button, Group, Image, Text, Title } from "@mantine/core";
 import React, { ForwardedRef, useContext, useState } from "react";
-import { Options } from "react-pdf/dist/cjs/shared/types";
+import type { Options } from "react-pdf/dist/cjs/shared/types";
 import { BLOCKS, INLINES } from "@contentful/rich-text-types";
 import ImageContainer from "components/common/Container/ImageContainer";
 import Asset from "components/common/Asset/Asset";

--- a/src/components/common/PhilPeople/PhilPeople.tsx
+++ b/src/components/common/PhilPeople/PhilPeople.tsx
@@ -2,7 +2,7 @@ import React, { useContext } from "react";
 import { TResource } from "types/resource";
 import PageContext from "contexts/PageContext";
 import { getColorFromStylingOptions } from "utils/stylingOptions";
-import { Options } from "react-pdf/dist/cjs/shared/types";
+import type { Options } from "react-pdf/dist/cjs/shared/types";
 import { Link } from "gatsby";
 import {
   Anchor,

--- a/src/components/section/ReferencedSection/ReferencedSection.tsx
+++ b/src/components/section/ReferencedSection/ReferencedSection.tsx
@@ -13,10 +13,8 @@ import {
 import { getLink } from "utils/getLink";
 import slugify from "slugify";
 import { getWindowProperty } from "utils/getWindowProperty";
-import * as FullStory from "@fullstory/browser";
 import { isProduction } from "utils/isProduction";
 import { getIdSlugifyForDiv } from "utils/utils";
-import mixpanel from "mixpanel-browser";
 import PageContext from "contexts/PageContext";
 import { FIELD_PAGE, HCP_PAGE, HOME, PATIENTS_PAGE,OUR_SOLUTIONS, PAGES_TITLE } from "constants/page";
 import ReferencedSectionTitle from "./ReferencedSectionTitle";
@@ -64,20 +62,27 @@ const ReferencedSection: React.FC<ReferencedSectionProps> = ({
   const isSmallDevice = useIsSmallDevice();
 
   React.useEffect(() => {
-    try {
-      const isFromSMSIntro = params.get("isFromSMSIntro");
-      if (
-        section.referenceType === ReferenceTypeEnum["Stats Card with Arrows"] &&
-        isFromSMSIntro === "true" &&
-        isProduction
-      ) {
-        mixpanel.init(process.env.GATSBY_MIXPANEL_TOKEN ?? "");
-        FullStory.init({ orgId: process.env.GATSBY_FULLSTORY_ORG_ID ?? "" });
-        mixpanel.track("PhilIntro_SMS_Clicked");
+    const run = async () => {
+      try {
+        const isFromSMSIntro = params.get("isFromSMSIntro");
+        if (
+          section.referenceType === ReferenceTypeEnum["Stats Card with Arrows"] &&
+          isFromSMSIntro === "true" &&
+          isProduction
+        ) {
+          const [{ default: mixpanel }, FullStory] = await Promise.all([
+            import("mixpanel-browser"),
+            import("@fullstory/browser"),
+          ]);
+          mixpanel.init(process.env.GATSBY_MIXPANEL_TOKEN ?? "");
+          FullStory.init({ orgId: process.env.GATSBY_FULLSTORY_ORG_ID ?? "" });
+          mixpanel.track("PhilIntro_SMS_Clicked");
+        }
+      } catch (error: unknown) {
+        console.log(error);
       }
-    } catch (error: unknown) {
-      console.log(error);
-    }
+    };
+    void run();
   }, []);
 
   // TODO: Refactor Get grid span based on resource type


### PR DESCRIPTION
 1. Removed Tabler Icons webfont CDN (index.css)                                                                                                                                               
  - Eliminated @import url("https://cdn.jsdelivr.net/.../tabler-icons.min.css") — a ~300KB CSS file + font files loaded from an external CDN on every page                                      
  - The single usage (content: "\ea1f") was replaced with content: "→" — no font dependency needed                                                                                              
  - Also removes the external CDN request + eliminates a render-blocking resource                                                                                                               
                                                                                                                                                                                                
  2. FullStory + Mixpanel lazy-loaded (ReferencedSection.tsx)                                                                                                                                   
  - Both were statically imported, so their full bundles (~150KB combined) were included in every page's JS                                                                                     
  - Now dynamically imported with Promise.all([import(...), import(...)]) only when needed — only fires on pages with Stats Card with Arrows sections where ?isFromSMSIntro=true                
                                                                                                                                                                                              
  3. react-pdf type-only imports (PhilPeople.tsx, LeaderProfileCard.tsx)                                                                                                                        
  - Changed import { Options } → import type { Options } — TypeScript types are erased at compile time, so the react-pdf runtime bundle is no longer pulled into those chunks (it's only ever   
  loaded via the @loadable/component dynamic import in Asset.tsx)                                                                                                                               

### JIRA
<!-- Replace this line with Ticket link -->

## Description
<!-- Please include a summary of the changes and the related issue. -->

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
