### PR TITLE
fix: pharma video

### DIFF
--- a/src/templates/page.tsx
+++ b/src/templates/page.tsx
@@ -588,6 +588,7 @@ export const query = graphql`
                 }
               }
               ... on ContentfulMediaItem {
+                contentful_id
                 name
                 media {
                   gatsbyImageData(
@@ -679,6 +680,7 @@ export const query = graphql`
                 heading
               }
               ... on ContentfulMediaItem {
+                contentful_id
                 name
                 media {
                   gatsbyImageData(


### PR DESCRIPTION
### JIRA
<!-- Replace this line with Ticket link -->

## Description
The glitch on our Pharma page.
On our Pharma page, in the "Our Platform" section, it should have a video but it was not showing. 
I've fixed it by importing the contentful_id in both the leftcolumn and right column of text and text column.

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [x] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [x] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->
<img width="1754" height="925" alt="image" src="https://github.com/user-attachments/assets/e1ded64a-d34e-4350-835a-0f67916280cb" />

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
