### PR TITLE
feat(pharma): add click-to-play video components and update video links

### DIFF
--- a/src/pages/pharma/index.tsx
+++ b/src/pages/pharma/index.tsx
@@ -339,7 +339,7 @@ const PlatformSection = () => (
             videoId="WmuyIuwHkgM"
             thumb={philDirectThumb}
             alt="PHIL Direct video thumbnail"
-            tag="PHIL Direct-to-Patient"
+            tag="PHIL Direct"
             label="Watch PHIL Direct video"
           />
           <div className={classes.pfVideoBody}>

--- a/src/pages/pharma/index.tsx
+++ b/src/pages/pharma/index.tsx
@@ -237,6 +237,56 @@ const PartnersSection = () => {
   );
 };
 
+// ─── Inline click-to-play video facade ──────────────────────────────────────
+
+const VideoThumb = ({
+  videoId,
+  thumb,
+  alt,
+  tag,
+  label,
+}: {
+  videoId: string;
+  thumb: string;
+  alt: string;
+  tag: string;
+  label: string;
+}) => {
+  const [playing, setPlaying] = useState(false);
+
+  if (playing) {
+    return (
+      <div className={classes.pfVideoThumb}>
+        <iframe
+          className={classes.pfVideoIframe}
+          src={`https://www.youtube-nocookie.com/embed/${videoId}?rel=0&modestbranding=1&autoplay=1`}
+          title={label}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          referrerPolicy="strict-origin-when-cross-origin"
+        />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      className={classes.pfVideoThumb}
+      onClick={() => setPlaying(true)}
+      aria-label={label}
+    >
+      <img src={thumb} alt={alt} loading="lazy" />
+      <span className={classes.pfVideoTag}>{tag}</span>
+      <span className={classes.playOverlay} aria-hidden="true">
+        <span className={classes.playBtn}>
+          <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7L8 5z" /></svg>
+        </span>
+      </span>
+    </button>
+  );
+};
+
 // ─── SECTION 3: Our Platform ─────────────────────────────────────────────────
 
 const PlatformSection = () => (
@@ -253,21 +303,13 @@ const PlatformSection = () => (
 
       <div className={classes.pfVideos}>
         <div className={classes.pfVideoCard}>
-          <a
-            className={classes.pfVideoThumb}
-            href="https://youtu.be/dn-MvZkdHTU"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Watch PHIL Core video"
-          >
-            <img src={philCoreThumb} alt="PHIL Core video thumbnail" loading="lazy" />
-            <span className={classes.pfVideoTag}>PHIL Digital Hub</span>
-            <span className={classes.playOverlay} aria-hidden="true">
-              <span className={classes.playBtn}>
-                <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7L8 5z" /></svg>
-              </span>
-            </span>
-          </a>
+          <VideoThumb
+            videoId="kfMiJUwZkFE"
+            thumb={philCoreThumb}
+            alt="PHIL Core video thumbnail"
+            tag="PHIL Digital Hub"
+            label="Watch PHIL Core video"
+          />
           <div className={classes.pfVideoBody}>
             <h3 className={classes.pfVideoTitle}>
               Achieve Commercial Success with a Flexible Digital Hub Solution
@@ -293,32 +335,22 @@ const PlatformSection = () => (
         </div>
 
         <div className={classes.pfVideoCardFlipped}>
-          <a
-            className={classes.pfVideoThumb}
-            href="https://www.youtube.com/watch?v=WmuyIuwHkgM"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Watch PHIL Direct video"
-          >
-            <img src={philDirectThumb} alt="PHIL Direct video thumbnail" loading="lazy" />
-            <span className={classes.pfVideoTag}>PHIL Direct-to-Patient</span>
-            <span className={classes.playOverlay} aria-hidden="true">
-              <span className={classes.playBtn}>
-                <svg viewBox="0 0 24 24"><path d="M8 5v14l11-7L8 5z" /></svg>
-              </span>
-            </span>
-          </a>
+          <VideoThumb
+            videoId="WmuyIuwHkgM"
+            thumb={philDirectThumb}
+            alt="PHIL Direct video thumbnail"
+            tag="PHIL Direct-to-Patient"
+            label="Watch PHIL Direct video"
+          />
           <div className={classes.pfVideoBody}>
             <h3 className={classes.pfVideoTitle}>
               Create a Future-ready, Direct-to-Patient Experience with a Proven DTP Solution
             </h3>
             <p className={classes.pfVideoDesc}>
-              PHIL Direct-to-Patient (DTP) connects intake, telemedicine, coverage routing, and
-              fulfillment in one seamless experience, helping brands drive patient starts, maximize
-              affordability, and promote adherence beyond the first fill.
+              PHIL Direct connects intake, telemedicine, coverage routing, and fulfillment in one seamless DTP experience, helping brands drive patient starts, maximize affordability, and promote adherence beyond the first fill.
             </p>
             <Link className={classes.btnText} to="/solution/direct/">
-              Explore PHIL Direct-to-Patient <span aria-hidden="true">→</span>
+              Explore PHIL Direct <span aria-hidden="true">→</span>
             </Link>
           </div>
         </div>

--- a/src/pages/pharma/pharma.module.css
+++ b/src/pages/pharma/pharma.module.css
@@ -450,6 +450,18 @@
   transition: transform 280ms var(--ease-standard), box-shadow 280ms var(--ease-standard);
   width: 100%;
   min-width: 0;
+  padding: 0;
+  border: none;
+  appearance: none;
+  cursor: pointer;
+}
+.pfVideoIframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: inherit;
 }
 .pfVideoThumb:hover {
   transform: translateY(-3px);

--- a/src/pages/solution/direct/_sections/VideoBand.tsx
+++ b/src/pages/solution/direct/_sections/VideoBand.tsx
@@ -1,39 +1,55 @@
-import React from "react";
+import React, { useState } from "react";
 
-export const VideoBandSection: React.FC = () => (
-  <section id="video" className="band video-section" data-screen-label="03 Video">
-    <div className="xl-container">
-      <div className="video-band">
-        <div className="vb-copy">
-          <h2>Discover the DTP Possibilities with PHIL Direct</h2>
-          <p>
-            Maximize patient access, affordability, and adherence while
-            safeguarding commercial performance with PHIL Direct.
-          </p>
+export const VideoBandSection: React.FC = () => {
+  const [playing, setPlaying] = useState(false);
+
+  return (
+    <section id="video" className="band video-section" data-screen-label="03 Video">
+      <div className="xl-container">
+        <div className="video-band">
+          <div className="vb-copy">
+            <h2>Discover the DTP Possibilities with PHIL Direct</h2>
+            <p>
+              Maximize patient access, affordability, and adherence while
+              safeguarding commercial performance with PHIL Direct.
+            </p>
+          </div>
+          {playing ? (
+            <div className="video-thumb">
+              <iframe
+                className="video-iframe"
+                src="https://www.youtube-nocookie.com/embed/WmuyIuwHkgM?rel=0&modestbranding=1&autoplay=1"
+                title="PHIL Direct overview video"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                allowFullScreen
+                referrerPolicy="strict-origin-when-cross-origin"
+              />
+            </div>
+          ) : (
+            <button
+              type="button"
+              className="video-thumb"
+              onClick={() => setPlaying(true)}
+              aria-label="Watch the PHIL Direct video"
+            >
+              <img
+                src="https://img.youtube.com/vi/WmuyIuwHkgM/maxresdefault.jpg"
+                alt="PHIL Direct overview video"
+                width={1280}
+                height={720}
+                loading="lazy"
+              />
+              <span className="play-overlay" aria-hidden="true">
+                <span className="play-btn">
+                  <svg viewBox="0 0 24 24">
+                    <path d="M8 5v14l11-7L8 5z" />
+                  </svg>
+                </span>
+              </span>
+            </button>
+          )}
         </div>
-        <a
-          className="video-thumb"
-          href="https://www.youtube.com/watch?v=WmuyIuwHkgM"
-          target="_blank"
-          rel="noopener noreferrer"
-          aria-label="Watch the PHIL Direct video"
-        >
-          <img
-            src="https://img.youtube.com/vi/WmuyIuwHkgM/maxresdefault.jpg"
-            alt="PHIL Direct overview video"
-            width={1280}
-            height={720}
-            loading="lazy"
-          />
-          <span className="play-overlay" aria-hidden="true">
-            <span className="play-btn">
-              <svg viewBox="0 0 24 24">
-                <path d="M8 5v14l11-7L8 5z" />
-              </svg>
-            </span>
-          </span>
-        </a>
       </div>
-    </div>
-  </section>
-);
+    </section>
+  );
+};

--- a/src/pages/solution/direct/direct.css
+++ b/src/pages/solution/direct/direct.css
@@ -337,7 +337,8 @@
 .scope-direct .vb-watch .vw-ico svg { width: 12px; height: 12px; fill: var(--phil-pure); margin-left: 1px; }
 .scope-direct .vb-watch:hover { color: var(--phil-pure); }
 .scope-direct .vb-watch:hover .vw-ico { background: rgba(255,255,255,0.16); border-color: var(--phil-pure); }
-.scope-direct .video-thumb { position: relative; display: block; border-radius: 18px; overflow: hidden; box-shadow: 0 40px 70px -28px rgba(0,40,38,0.6); aspect-ratio: 16 / 9; background: #00615E; }
+.scope-direct .video-thumb { position: relative; display: block; border-radius: 18px; overflow: hidden; box-shadow: 0 40px 70px -28px rgba(0,40,38,0.6); aspect-ratio: 16 / 9; background: #00615E; width: 100%; padding: 0; border: none; appearance: none; cursor: pointer; }
+.scope-direct .video-iframe { position: absolute; inset: 0; width: 100%; height: 100%; border: 0; border-radius: inherit; }
 .scope-direct .video-thumb img { width: 100%; height: 100%; object-fit: cover; transition: transform 500ms var(--ease-standard); }
 .scope-direct .video-thumb:hover img { transform: scale(1.04); }
 .scope-direct .play-overlay { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: linear-gradient(180deg, rgba(10,10,10,0) 40%, rgba(0,40,38,0.35) 100%); }


### PR DESCRIPTION
- Create reusable VideoThumb component with click-to-play functionality for inline videos
- Replace external YouTube links with embedded iframe players on Pharma platform
- Update PHIL Core video ID from dn-MvZkdHTU to kfMiJUwZkFE
- Simplify PHIL Direct product copy and link text across platform
- Add button styling and iframe container styles for video player integration
- Implement click-to-play facade pattern to improve performance and UX
- Update VideoBand section on Direct solution page with new video component

### JIRA
<!-- Replace this line with Ticket link -->

## Description
<!-- Please include a summary of the changes and the related issue. -->

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
