### PR TITLE
fix(core): standardize SVG attributes and hide desktop timeline on mo…

### DIFF
--- a/src/pages/solution/core/_sections/DataTabs.tsx
+++ b/src/pages/solution/core/_sections/DataTabs.tsx
@@ -3,7 +3,7 @@ import philLogo from 'assets/images/phil-logo-green.png';
 
 // Lightbulb icon reused inside every mobile insight card.
 const INSIGHT_ICON = (
-	<svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg>
+	<svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg>
 );
 
 // Single source for the vertical mobile timeline (≤640px). Icons match the desktop
@@ -24,45 +24,45 @@ const JOURNEY_STEPS: JourneyStep[] = [
 		iconSide: 'right',
 		insight: 'Understand intake channel impact',
 		insightSide: 'left',
-		icon: (<svg viewBox="0 0 24 24"><rect x="9" y="2" width="6" height="4" rx="1" /><path d="M5 4h2a2 2 0 012 2v0a2 2 0 002 2h2a2 2 0 002-2v0a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="13" y2="16" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none"><rect x="9" y="2" width="6" height="4" rx="1" /><path d="M5 4h2a2 2 0 012 2v0a2 2 0 002 2h2a2 2 0 002-2v0a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="13" y2="16" /></svg>),
 	},
 	{
 		label: 'Patient Appointment',
 		iconSide: 'left',
-		icon: (<svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="16" y1="2" x2="16" y2="6" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none"><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="16" y1="2" x2="16" y2="6" /></svg>),
 	},
 	{
 		label: 'Prescription Generation',
 		iconSide: 'right',
 		insight: 'Analyze provider adoption',
 		insightSide: 'right',
-		icon: (<svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="5" rx="1.5" /><rect x="5" y="7" width="14" height="15" rx="2" /><line x1="9" y1="11" x2="15" y2="11" /><line x1="12" y1="11" x2="12" y2="17" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none"><rect x="6" y="2" width="12" height="5" rx="1.5" /><rect x="5" y="7" width="14" height="15" rx="2" /><line x1="9" y1="11" x2="15" y2="11" /><line x1="12" y1="11" x2="12" y2="17" /></svg>),
 	},
 	{
 		label: 'Prior Authorization',
 		iconSide: 'left',
 		insight: 'Track payer responses',
 		insightSide: 'left',
-		icon: (<svg viewBox="0 0 24 24"><path d="M12 2l7 4v6c0 4.4-3.1 8.5-7 10C8.1 20.5 5 16.4 5 12V6l7-4z" /><polyline points="9 12 11 14 15 10" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M12 2l7 4v6c0 4.4-3.1 8.5-7 10C8.1 20.5 5 16.4 5 12V6l7-4z" /><polyline points="9 12 11 14 15 10" /></svg>),
 	},
 	{
 		label: 'Affordable Pathways',
 		iconSide: 'right',
 		insight: 'Get visibility into program utilization',
 		insightSide: 'right',
-		icon: (<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /><path d="M15 9h-4.5a1.75 1.75 0 0 0 0 3.5h3a1.75 1.75 0 0 1 0 3.5H9" /><path d="M12 7.25v9.5" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none"><circle cx="12" cy="12" r="10" /><path d="M15 9h-4.5a1.75 1.75 0 0 0 0 3.5h3a1.75 1.75 0 0 1 0 3.5H9" /><path d="M12 7.25v9.5" /></svg>),
 	},
 	{
 		label: 'Shipping & Dispensing',
 		iconSide: 'left',
 		insight: 'Spot patient drop-off points',
 		insightSide: 'left',
-		icon: (<svg viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2" /><polyline points="16 2 12 7 8 2" /><line x1="2" y1="12" x2="22" y2="12" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none"><rect x="2" y="7" width="20" height="14" rx="2" /><polyline points="16 2 12 7 8 2" /><line x1="2" y1="12" x2="22" y2="12" /></svg>),
 	},
 	{
 		label: 'Refills',
 		iconSide: 'right',
-		icon: (<svg viewBox="0 0 24 24"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 102.13-9.36L1 10" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 102.13-9.36L1 10" /></svg>),
 	},
 ];
 
@@ -168,15 +168,16 @@ export const DataTabsSection: React.FC = () => (
           <article className="di-card" data-i="3" role="tabpanel">
             <div className="di-viz">
               <div className="dx-shot">
-                <div className="jt-wrap">
+                {/* Inline display:none = same FOUC guard as .jt-mobile; desktop media re-shows it. */}
+                <div className="jt-wrap" style={{display: 'none'}}>
                   <div className="jt-track">
                     <div className="jt-ext jt-ext-left" aria-hidden="true"><i></i><i></i><i></i></div>
                     <div className="jt-ext jt-ext-right" aria-hidden="true"><i></i><i></i><i></i></div>
 
                     <div className="jt-col jt-above">
-                      <div className="jt-visual"><div className="jt-insight" style={{'--jt-shift': '35px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx"><span className="jt-tx-d">Understand intake channel impact</span><span className="jt-tx-m">View intake conversion</span></div>
+                      <div className="jt-visual"><div className="jt-insight" style={{'--jt-shift': '35px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx"><span className="jt-tx-d">Understand intake channel impact</span><span className="jt-tx-m">View intake conversion</span></div>
                       </div><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><rect x="9" y="2" width="6" height="4" rx="1" /><path d="M5 4h2a2 2 0 012 2v0a2 2 0 002 2h2a2 2 0 002-2v0a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="13" y2="16" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none"><rect x="9" y="2" width="6" height="4" rx="1" /><path d="M5 4h2a2 2 0 012 2v0a2 2 0 002 2h2a2 2 0 002-2v0a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="13" y2="16" /></svg>
                       </span></div></div>
                       <div className="jt-stem"></div>
                       <div className="jt-dot"></div>
@@ -188,18 +189,18 @@ export const DataTabsSection: React.FC = () => (
                       <div className="jt-dot"></div>
                       <div className="jt-stem"></div>
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="14" x2="8" y2="14" strokeWidth="2.5" /><line x1="12" y1="14" x2="12" y2="14" strokeWidth="2.5" /><line x1="16" y1="14" x2="16" y2="14" strokeWidth="2.5" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none"><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="14" x2="8" y2="14" strokeWidth="2.5" /><line x1="12" y1="14" x2="12" y2="14" strokeWidth="2.5" /><line x1="16" y1="14" x2="16" y2="14" strokeWidth="2.5" /></svg>
                       </span></div></div>
                     </div>
 
                     <div className="jt-col jt-above">
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="5" rx="1.5" /><rect x="5" y="7" width="14" height="15" rx="2" /><line x1="9" y1="11" x2="15" y2="11" /><line x1="12" y1="11" x2="12" y2="17" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none"><rect x="6" y="2" width="12" height="5" rx="1.5" /><rect x="5" y="7" width="14" height="15" rx="2" /><line x1="9" y1="11" x2="15" y2="11" /><line x1="12" y1="11" x2="12" y2="17" /></svg>
                       </span></div></div>
                       <div className="jt-stem"></div>
                       <div className="jt-dot"></div>
                       <div className="jt-label">Prescription Generation</div>
-                      <div className="jt-insight jt-insight--flip jt-flip-anim" style={{'--jt-shift': '-133px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Analyze provider adoption</div></div>
+                      <div className="jt-insight jt-insight--flip jt-flip-anim" style={{'--jt-shift': '-133px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Analyze provider adoption</div></div>
                     </div>
 
                     <div className="jt-col jt-below">
@@ -207,14 +208,14 @@ export const DataTabsSection: React.FC = () => (
                       <div className="jt-dot"></div>
                       <div className="jt-stem"></div>
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><path d="M12 2l7 4v6c0 4.4-3.1 8.5-7 10C8.1 20.5 5 16.4 5 12V6l7-4z" /><polyline points="9 12 11 14 15 10" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M12 2l7 4v6c0 4.4-3.1 8.5-7 10C8.1 20.5 5 16.4 5 12V6l7-4z" /><polyline points="9 12 11 14 15 10" /></svg>
                       </span></div></div>
-                      <div className="jt-insight jt-insight--top" style={{'--jt-shift': '334px', top: '-108px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Track payer responses</div></div>
+                      <div className="jt-insight jt-insight--top" style={{'--jt-shift': '334px', top: '-108px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Track payer responses</div></div>
                     </div>
 
                     <div className="jt-col jt-above">
-                      <div className="jt-visual"><div className="jt-insight" style={{'--jt-shift': '-35px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Get visibility into program utilization</div></div><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /><path d="M15 9h-4.5a1.75 1.75 0 0 0 0 3.5h3a1.75 1.75 0 0 1 0 3.5H9" /><path d="M12 7.25v9.5" /></svg>
+                      <div className="jt-visual"><div className="jt-insight" style={{'--jt-shift': '-35px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Get visibility into program utilization</div></div><div className="jt-circle"><span className="jt-icon">
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none"><circle cx="12" cy="12" r="10" /><path d="M15 9h-4.5a1.75 1.75 0 0 0 0 3.5h3a1.75 1.75 0 0 1 0 3.5H9" /><path d="M12 7.25v9.5" /></svg>
                       </span></div></div>
                       <div className="jt-stem"></div>
                       <div className="jt-dot"></div>
@@ -226,25 +227,29 @@ export const DataTabsSection: React.FC = () => (
                       <div className="jt-dot"></div>
                       <div className="jt-stem"></div>
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2" /><polyline points="16 2 12 7 8 2" /><line x1="2" y1="12" x2="22" y2="12" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none"><rect x="2" y="7" width="20" height="14" rx="2" /><polyline points="16 2 12 7 8 2" /><line x1="2" y1="12" x2="22" y2="12" /></svg>
                       </span></div></div>
                     </div>
 
                     <div className="jt-col jt-above">
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 102.13-9.36L1 10" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 102.13-9.36L1 10" /></svg>
                       </span></div></div>
                       <div className="jt-stem"></div>
                       <div className="jt-dot"></div>
                       <div className="jt-label">Refills</div>
-                      <div className="jt-insight jt-insight--flip jt-flip-anim" style={{'--jt-shift': '-209px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Spot patient drop-off points</div></div>
+                      <div className="jt-insight jt-insight--flip jt-flip-anim" style={{'--jt-shift': '-209px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Spot patient drop-off points</div></div>
                     </div>
 
                   </div>
                 </div>
-                <div className="jt-mobile">
+                {/* Inline display:none prevents a production FOUC: .jt-mobile is always in the
+                    DOM and is only hidden by core.css (which loads async), so on the first
+                    uncached visit it would otherwise flash as huge unstyled black SVG icons.
+                    The mobile media query re-shows the styled version with !important. */}
+                <div className="jt-mobile" style={{display: 'none'}}>
                   <span className="jtm-ext jtm-ext-top" aria-hidden="true"><i></i><i></i><i></i></span>
-                  <ol className="jtm-list">
+                  <ol className="jtm-list" style={{listStyle: 'none', margin: '0 auto', padding: 0}}>
                     {JOURNEY_STEPS.map(step => {
                       const labelSide = step.iconSide === 'right' ? 'left' : 'right';
                       const iconEl = <span className="jtm-icon" key="icon">{step.icon}</span>;

--- a/src/pages/solution/core/core.css
+++ b/src/pages/solution/core/core.css
@@ -2016,12 +2016,19 @@
      horizontal one. The old approach (jt-wrap overflow-x:auto + jt-track min-width:700) gave
      the timeline an internal horizontal scrollbar at tablet widths — this removes it. */
   .scope .di-card[data-i="3"] .jt-wrap { display: none; }
-  .scope .di-card[data-i="3"] .jt-mobile { display: block; }
+  /* !important overrides the inline display:none on .jt-mobile (FOUC guard, see DataTabs). */
+  .scope .di-card[data-i="3"] .jt-mobile { display: block !important; }
   /* With the vertical timeline, drop the floating "PHIL AI Insights" card to the bottom of
      the section at full width (instead of overlapping the journey). */
   .scope .di-card[data-i="3"] .di-viz { flex-direction: column; }
   .scope .di-card[data-i="3"] .tq-pop { position: relative; right: auto !important; bottom: auto !important; width: 100% !important; max-width: none; margin: 22px 0 0; }
 
+}
+
+/* Desktop (>768px): reveal the horizontal timeline, overriding its inline display:none
+   (FOUC guard). Above the sm breakpoint so it never overlaps the vertical layout. */
+@media (min-width: 48.0625em) {
+  .scope .di-card[data-i="3"] .jt-wrap { display: block !important; }
 }
 
 @media (max-width: $phil-breakpoint-xs) {


### PR DESCRIPTION
…bile

- Add width, height, and fill="none" attributes to all SVG icons for consistent rendering
- Update 8 SVG icons in JOURNEY_STEPS array with explicit dimensions and fill properties
- Update inline SVG elements in JSX with standardized attributes
- Hide desktop timeline wrapper on mobile with inline display:none style
- Add explanatory comment for FOUC (Flash of Unstyled Content) guard on mobile view
- Ensures proper SVG sizing and prevents layout shifts across viewport sizes

### JIRA
<!-- Replace this line with Ticket link -->

## Description
<!-- Please include a summary of the changes and the related issue. -->

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
