### PR TITLE
style(core): standardize SVG icon styling across journey timeline

### DIFF
--- a/src/pages/solution/core/_sections/DataTabs.tsx
+++ b/src/pages/solution/core/_sections/DataTabs.tsx
@@ -3,7 +3,7 @@ import philLogo from 'assets/images/phil-logo-green.png';
 
 // Lightbulb icon reused inside every mobile insight card.
 const INSIGHT_ICON = (
-	<svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg>
+	<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg>
 );
 
 // Single source for the vertical mobile timeline (≤640px). Icons match the desktop
@@ -24,45 +24,45 @@ const JOURNEY_STEPS: JourneyStep[] = [
 		iconSide: 'right',
 		insight: 'Understand intake channel impact',
 		insightSide: 'left',
-		icon: (<svg viewBox="0 0 24 24"><rect x="9" y="2" width="6" height="4" rx="1" /><path d="M5 4h2a2 2 0 012 2v0a2 2 0 002 2h2a2 2 0 002-2v0a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="13" y2="16" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="9" y="2" width="6" height="4" rx="1" /><path d="M5 4h2a2 2 0 012 2v0a2 2 0 002 2h2a2 2 0 002-2v0a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="13" y2="16" /></svg>),
 	},
 	{
 		label: 'Patient Appointment',
 		iconSide: 'left',
-		icon: (<svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="16" y1="2" x2="16" y2="6" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="16" y1="2" x2="16" y2="6" /></svg>),
 	},
 	{
 		label: 'Prescription Generation',
 		iconSide: 'right',
 		insight: 'Analyze provider adoption',
 		insightSide: 'right',
-		icon: (<svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="5" rx="1.5" /><rect x="5" y="7" width="14" height="15" rx="2" /><line x1="9" y1="11" x2="15" y2="11" /><line x1="12" y1="11" x2="12" y2="17" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="6" y="2" width="12" height="5" rx="1.5" /><rect x="5" y="7" width="14" height="15" rx="2" /><line x1="9" y1="11" x2="15" y2="11" /><line x1="12" y1="11" x2="12" y2="17" /></svg>),
 	},
 	{
 		label: 'Prior Authorization',
 		iconSide: 'left',
 		insight: 'Track payer responses',
 		insightSide: 'left',
-		icon: (<svg viewBox="0 0 24 24"><path d="M12 2l7 4v6c0 4.4-3.1 8.5-7 10C8.1 20.5 5 16.4 5 12V6l7-4z" /><polyline points="9 12 11 14 15 10" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M12 2l7 4v6c0 4.4-3.1 8.5-7 10C8.1 20.5 5 16.4 5 12V6l7-4z" /><polyline points="9 12 11 14 15 10" /></svg>),
 	},
 	{
 		label: 'Affordable Pathways',
 		iconSide: 'right',
 		insight: 'Get visibility into program utilization',
 		insightSide: 'right',
-		icon: (<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /><path d="M15 9h-4.5a1.75 1.75 0 0 0 0 3.5h3a1.75 1.75 0 0 1 0 3.5H9" /><path d="M12 7.25v9.5" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><circle cx="12" cy="12" r="10" /><path d="M15 9h-4.5a1.75 1.75 0 0 0 0 3.5h3a1.75 1.75 0 0 1 0 3.5H9" /><path d="M12 7.25v9.5" /></svg>),
 	},
 	{
 		label: 'Shipping & Dispensing',
 		iconSide: 'left',
 		insight: 'Spot patient drop-off points',
 		insightSide: 'left',
-		icon: (<svg viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2" /><polyline points="16 2 12 7 8 2" /><line x1="2" y1="12" x2="22" y2="12" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="2" y="7" width="20" height="14" rx="2" /><polyline points="16 2 12 7 8 2" /><line x1="2" y1="12" x2="22" y2="12" /></svg>),
 	},
 	{
 		label: 'Refills',
 		iconSide: 'right',
-		icon: (<svg viewBox="0 0 24 24"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 102.13-9.36L1 10" /></svg>),
+		icon: (<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 102.13-9.36L1 10" /></svg>),
 	},
 ];
 
@@ -116,7 +116,7 @@ export const DataTabsSection: React.FC = () => (
                 </div>
               </div>
               <div className="tq-pop">
-                <div className="tq-head"><div className="tq-badge"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 1.6c.5 5.2 3.9 8.6 9.1 9.1-5.2.5-8.6 3.9-9.1 9.1-.5-5.2-3.9-8.6-9.1-9.1 5.2-.5 8.6-3.9 9.1-9.1z" /></svg></div><div className="tq-headtext"><span className="tq-eyebrow">PHIL AI Insights</span><span className="tq-title">Optimization Opportunity</span></div></div>
+                <div className="tq-head"><div className="tq-badge"><svg viewBox="0 0 24 24" aria-hidden="true" width="19" height="19" fill="currentColor"><path d="M12 1.6c.5 5.2 3.9 8.6 9.1 9.1-5.2.5-8.6 3.9-9.1 9.1-.5-5.2-3.9-8.6-9.1-9.1 5.2-.5 8.6-3.9 9.1-9.1z" /></svg></div><div className="tq-headtext"><span className="tq-eyebrow">PHIL AI Insights</span><span className="tq-title">Optimization Opportunity</span></div></div>
                 <p className="tq-body"><b>Atlanta West, GA</b> is up <span className="tq-hl">134%</span> in NRx this quarter, but 3 high-volume prescribers haven’t enrolled a patient in 30+ days.</p>
               </div>
             </div>
@@ -155,7 +155,7 @@ export const DataTabsSection: React.FC = () => (
                 </div>
               </div>
               <div className="tq-pop">
-                <div className="tq-head"><div className="tq-badge"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 1.6c.5 5.2 3.9 8.6 9.1 9.1-5.2.5-8.6 3.9-9.1 9.1-.5-5.2-3.9-8.6-9.1-9.1 5.2-.5 8.6-3.9 9.1-9.1z" /></svg></div><div className="tq-headtext"><span className="tq-eyebrow">PHIL AI Insights</span><span className="tq-title">Optimization Opportunity</span></div></div>
+                <div className="tq-head"><div className="tq-badge"><svg viewBox="0 0 24 24" aria-hidden="true" width="19" height="19" fill="currentColor"><path d="M12 1.6c.5 5.2 3.9 8.6 9.1 9.1-5.2.5-8.6 3.9-9.1 9.1-.5-5.2-3.9-8.6-9.1-9.1 5.2-.5 8.6-3.9 9.1-9.1z" /></svg></div><div className="tq-headtext"><span className="tq-eyebrow">PHIL AI Insights</span><span className="tq-title">Optimization Opportunity</span></div></div>
                 <p className="tq-body">Missing script information has gone down <span className="tq-hl">13%</span> in the last 30 days.</p>
               </div>
             </div>
@@ -174,9 +174,9 @@ export const DataTabsSection: React.FC = () => (
                     <div className="jt-ext jt-ext-right" aria-hidden="true"><i></i><i></i><i></i></div>
 
                     <div className="jt-col jt-above">
-                      <div className="jt-visual"><div className="jt-insight" style={{'--jt-shift': '35px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx"><span className="jt-tx-d">Understand intake channel impact</span><span className="jt-tx-m">View intake conversion</span></div>
+                      <div className="jt-visual"><div className="jt-insight" style={{'--jt-shift': '35px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx"><span className="jt-tx-d">Understand intake channel impact</span><span className="jt-tx-m">View intake conversion</span></div>
                       </div><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><rect x="9" y="2" width="6" height="4" rx="1" /><path d="M5 4h2a2 2 0 012 2v0a2 2 0 002 2h2a2 2 0 002-2v0a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="13" y2="16" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="9" y="2" width="6" height="4" rx="1" /><path d="M5 4h2a2 2 0 012 2v0a2 2 0 002 2h2a2 2 0 002-2v0a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2H5a2 2 0 01-2-2V6a2 2 0 012-2z" /><line x1="9" y1="12" x2="15" y2="12" /><line x1="9" y1="16" x2="13" y2="16" /></svg>
                       </span></div></div>
                       <div className="jt-stem"></div>
                       <div className="jt-dot"></div>
@@ -188,18 +188,18 @@ export const DataTabsSection: React.FC = () => (
                       <div className="jt-dot"></div>
                       <div className="jt-stem"></div>
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="14" x2="8" y2="14" strokeWidth="2.5" /><line x1="12" y1="14" x2="12" y2="14" strokeWidth="2.5" /><line x1="16" y1="14" x2="16" y2="14" strokeWidth="2.5" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="3" y="4" width="18" height="18" rx="2" /><line x1="3" y1="10" x2="21" y2="10" /><line x1="8" y1="2" x2="8" y2="6" /><line x1="16" y1="2" x2="16" y2="6" /><line x1="8" y1="14" x2="8" y2="14" strokeWidth="2.5" /><line x1="12" y1="14" x2="12" y2="14" strokeWidth="2.5" /><line x1="16" y1="14" x2="16" y2="14" strokeWidth="2.5" /></svg>
                       </span></div></div>
                     </div>
 
                     <div className="jt-col jt-above">
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><rect x="6" y="2" width="12" height="5" rx="1.5" /><rect x="5" y="7" width="14" height="15" rx="2" /><line x1="9" y1="11" x2="15" y2="11" /><line x1="12" y1="11" x2="12" y2="17" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="6" y="2" width="12" height="5" rx="1.5" /><rect x="5" y="7" width="14" height="15" rx="2" /><line x1="9" y1="11" x2="15" y2="11" /><line x1="12" y1="11" x2="12" y2="17" /></svg>
                       </span></div></div>
                       <div className="jt-stem"></div>
                       <div className="jt-dot"></div>
                       <div className="jt-label">Prescription Generation</div>
-                      <div className="jt-insight jt-insight--flip jt-flip-anim" style={{'--jt-shift': '-133px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Analyze provider adoption</div></div>
+                      <div className="jt-insight jt-insight--flip jt-flip-anim" style={{'--jt-shift': '-133px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Analyze provider adoption</div></div>
                     </div>
 
                     <div className="jt-col jt-below">
@@ -207,14 +207,14 @@ export const DataTabsSection: React.FC = () => (
                       <div className="jt-dot"></div>
                       <div className="jt-stem"></div>
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><path d="M12 2l7 4v6c0 4.4-3.1 8.5-7 10C8.1 20.5 5 16.4 5 12V6l7-4z" /><polyline points="9 12 11 14 15 10" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M12 2l7 4v6c0 4.4-3.1 8.5-7 10C8.1 20.5 5 16.4 5 12V6l7-4z" /><polyline points="9 12 11 14 15 10" /></svg>
                       </span></div></div>
-                      <div className="jt-insight jt-insight--top" style={{'--jt-shift': '334px', top: '-108px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Track payer responses</div></div>
+                      <div className="jt-insight jt-insight--top" style={{'--jt-shift': '334px', top: '-108px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Track payer responses</div></div>
                     </div>
 
                     <div className="jt-col jt-above">
-                      <div className="jt-visual"><div className="jt-insight" style={{'--jt-shift': '-35px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Get visibility into program utilization</div></div><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10" /><path d="M15 9h-4.5a1.75 1.75 0 0 0 0 3.5h3a1.75 1.75 0 0 1 0 3.5H9" /><path d="M12 7.25v9.5" /></svg>
+                      <div className="jt-visual"><div className="jt-insight" style={{'--jt-shift': '-35px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Get visibility into program utilization</div></div><div className="jt-circle"><span className="jt-icon">
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><circle cx="12" cy="12" r="10" /><path d="M15 9h-4.5a1.75 1.75 0 0 0 0 3.5h3a1.75 1.75 0 0 1 0 3.5H9" /><path d="M12 7.25v9.5" /></svg>
                       </span></div></div>
                       <div className="jt-stem"></div>
                       <div className="jt-dot"></div>
@@ -226,25 +226,25 @@ export const DataTabsSection: React.FC = () => (
                       <div className="jt-dot"></div>
                       <div className="jt-stem"></div>
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><rect x="2" y="7" width="20" height="14" rx="2" /><polyline points="16 2 12 7 8 2" /><line x1="2" y1="12" x2="22" y2="12" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><rect x="2" y="7" width="20" height="14" rx="2" /><polyline points="16 2 12 7 8 2" /><line x1="2" y1="12" x2="22" y2="12" /></svg>
                       </span></div></div>
                     </div>
 
                     <div className="jt-col jt-above">
                       <div className="jt-visual"><div className="jt-circle"><span className="jt-icon">
-                        <svg viewBox="0 0 24 24"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 102.13-9.36L1 10" /></svg>
+                        <svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><polyline points="1 4 1 10 7 10" /><path d="M3.51 15a9 9 0 102.13-9.36L1 10" /></svg>
                       </span></div></div>
                       <div className="jt-stem"></div>
                       <div className="jt-dot"></div>
                       <div className="jt-label">Refills</div>
-                      <div className="jt-insight jt-insight--flip jt-flip-anim" style={{'--jt-shift': '-209px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Spot patient drop-off points</div></div>
+                      <div className="jt-insight jt-insight--flip jt-flip-anim" style={{'--jt-shift': '-209px'}}><div className="jt-ins-head"><span className="jt-ins-ico"><svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" strokeWidth="1.8"><path d="M9 18h6" /><path d="M10 22h4" /><path d="M12 2a7 7 0 00-4.2 12.6c.5.4.8 1 .9 1.6l.1.8h6.4l.1-.8c.1-.6.4-1.2.9-1.6A7 7 0 0012 2z" /></svg></span><span className="jt-ins-ey">Insight</span></div><div className="jt-ins-tx">Spot patient drop-off points</div></div>
                     </div>
 
                   </div>
                 </div>
                 <div className="jt-mobile">
                   <span className="jtm-ext jtm-ext-top" aria-hidden="true"><i></i><i></i><i></i></span>
-                  <ol className="jtm-list">
+                  <ol className="jtm-list" style={{ listStyle: 'none' }}>
                     {JOURNEY_STEPS.map(step => {
                       const labelSide = step.iconSide === 'right' ? 'left' : 'right';
                       const iconEl = <span className="jtm-icon" key="icon">{step.icon}</span>;
@@ -273,7 +273,7 @@ export const DataTabsSection: React.FC = () => (
                 </div>
               </div>
               <div className="tq-pop">
-                <div className="tq-head"><div className="tq-badge"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 1.6c.5 5.2 3.9 8.6 9.1 9.1-5.2.5-8.6 3.9-9.1 9.1-.5-5.2-3.9-8.6-9.1-9.1 5.2-.5 8.6-3.9 9.1-9.1z" /></svg></div><div className="tq-headtext"><span className="tq-eyebrow">PHIL AI Insights</span><span className="tq-title">Optimization Opportunity</span></div></div>
+                <div className="tq-head"><div className="tq-badge"><svg viewBox="0 0 24 24" aria-hidden="true" width="19" height="19" fill="currentColor"><path d="M12 1.6c.5 5.2 3.9 8.6 9.1 9.1-5.2.5-8.6 3.9-9.1 9.1-.5-5.2-3.9-8.6-9.1-9.1 5.2-.5 8.6-3.9 9.1-9.1z" /></svg></div><div className="tq-headtext"><span className="tq-eyebrow">PHIL AI Insights</span><span className="tq-title">Optimization Opportunity</span></div></div>
                 <p className="tq-body">Refill adherence is up <span className="tq-hl">32%</span> over the last 60 days.</p>
               </div>
             </div>
@@ -316,7 +316,7 @@ export const DataTabsSection: React.FC = () => (
 
                 <div className="aid-card aid-ai" id="aidAi">
                   <div className="aid-ai-head">
-                    <div className="tq-badge"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 1.6c.5 5.2 3.9 8.6 9.1 9.1-5.2.5-8.6 3.9-9.1 9.1-.5-5.2-3.9-8.6-9.1-9.1 5.2-.5 8.6-3.9 9.1-9.1z" /></svg></div>
+                    <div className="tq-badge"><svg viewBox="0 0 24 24" aria-hidden="true" width="19" height="19" fill="currentColor"><path d="M12 1.6c.5 5.2 3.9 8.6 9.1 9.1-5.2.5-8.6 3.9-9.1 9.1-.5-5.2-3.9-8.6-9.1-9.1 5.2-.5 8.6-3.9 9.1-9.1z" /></svg></div>
                     <div className="tq-headtext"><span className="tq-eyebrow">PHIL AI Insights</span><span className="tq-title">Optimization Opportunity</span></div>
                   </div>
                   <div className="aid-msg">

--- a/src/pages/solution/core/core.css
+++ b/src/pages/solution/core/core.css
@@ -2022,6 +2022,13 @@
   .scope .di-card[data-i="3"] .di-viz { flex-direction: column; }
   .scope .di-card[data-i="3"] .tq-pop { position: relative; right: auto !important; bottom: auto !important; width: 100% !important; max-width: none; margin: 22px 0 0; }
 
+  /* Re-apply horizontal clipping ONLY on mobile. Here the horizontal `.jt-wrap`
+     (whose `.jt-above` cards overflow upward) is display:none, so the Safari
+     `overflow-x: clip` "clips both axes" bug can't cut anything vertically — the
+     vertical `.jt-mobile` timeline only needs its sideways spill contained, which
+     keeps the horizontal scrollbar away. Desktop intentionally leaves this off. */
+  .scope .di-viz .dx-shot { overflow-x: clip; }
+
 }
 
 @media (max-width: $phil-breakpoint-xs) {
@@ -2036,7 +2043,12 @@
 
 .scope .di-viz { position: relative; order: 1; overflow: hidden; background: linear-gradient(135deg, #F0FAF9 0%, #E8F4F1 100%); border-top: 1px solid var(--phil-base); display: flex; align-items: center; justify-content: center; padding: 28px; flex: 1 1 auto; }
 
-.scope .di-viz .dx-shot { margin: 0; padding: 0; background: transparent; border: 0; box-shadow: none; width: 100%; overflow-x: clip; }
+/* No `overflow-x: clip` here. Safari/WebKit treats `overflow-x: clip` as clipping
+   BOTH axes, which cut off the `.jt-above` insight cards that intentionally overflow
+   upward (Chromium clips x-only and was fine). `.di-viz` already has `overflow: hidden`,
+   so the wide timeline is still clipped horizontally — this just lets the insight
+   cards show consistently across browsers. */
+.scope .di-viz .dx-shot { margin: 0; padding: 0; background: transparent; border: 0; box-shadow: none; width: 100%; }
 
 .scope .di-viz .sq-table-wrap, .scope .di-viz .sq-table-wrap.sq-hcp { max-width: 920px; margin: 0 auto; }
 


### PR DESCRIPTION
- Add consistent width, height, fill, and strokeWidth attributes to all timeline step icons
- Update insight lightbulb icon with explicit sizing (24x24) and stroke styling
- Standardize all journey step SVGs with fill="none", stroke="currentColor", and strokeWidth="1.8"
- Update PHIL AI Insights badge icons with width="19", height="19", and fill="currentColor"
- Ensure visual consistency and proper icon rendering across mobile timeline components

### JIRA
<!-- Replace this line with Ticket link -->

## Description
<!-- Please include a summary of the changes and the related issue. -->

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines

## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
