### PR TITLE
feat(pages): add anchor navigation to /patients and /providers video sections with scroll offset

### DIFF
--- a/src/pages/patients/index.tsx
+++ b/src/pages/patients/index.tsx
@@ -407,7 +407,7 @@ const StepsSection = () => (
 // ─── Video ───────────────────────────────────────────────────────────────────
 
 const VideoSection = () => (
-  <section className={classes.video__section}>
+  <section className={classes.video__section} id="video">
     <div className="xl-container">
       <div className={classes.sectionHead}>
         <h2>How PHILRx Helps You Save on Your Prescriptions</h2>

--- a/src/pages/patients/patients.module.css
+++ b/src/pages/patients/patients.module.css
@@ -622,6 +622,7 @@
 .video__section {
   padding: 72px 0 50px;
   background: #ffffff;
+  scroll-margin-top: calc(var(--navbar-height) + var(--announcment-bar-height) + 5px);
 }
 
 .videoFrame {

--- a/src/pages/providers/index.tsx
+++ b/src/pages/providers/index.tsx
@@ -517,7 +517,7 @@ const StepsSection = () => (
 // ─── Video ────────────────────────────────────────────────────────────────────
 
 const VideoSection = () => (
-  <section className={classes.videoSection}>
+  <section className={classes.videoSection} id="video">
     <div className="xl-container">
       <div className={`${classes.sectionHead} ${classes.sectionHeadWide}`}>
         <h2>Sending a Script to PHILRx is Easy</h2>

--- a/src/pages/providers/providers.module.css
+++ b/src/pages/providers/providers.module.css
@@ -701,6 +701,8 @@
 .videoSection {
   padding: 70px 0 50px;
   background: #ffffff;
+  /* No info bar renders on /providers, so only the sticky navbar offsets the anchor. */
+  scroll-margin-top: calc(var(--navbar-height) + 16px);
 }
 
 .videoFrame {


### PR DESCRIPTION
- Add id="video" anchor to VideoSection components on patients and providers pages
- Implement scroll-margin-top on video sections to account for fixed navbar and announcement bar heights
- Configure scroll offset for /patients page: navbar + announcement bar + 5px buffer
- Configure scroll offset for /providers page: navbar + 16px buffer (no announcement bar)
- Enables smooth anchor navigation to video sections while preventing content overlap with fixed UI elements

### JIRA
<!-- Replace this line with Ticket link -->
https://phildotus.atlassian.net/browse/MRTG-1439

## Description
<!-- Please include a summary of the changes and the related issue. -->

## Related PRs
<!-- Link the issues this PR closes or relates to -->

## Type of Change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix
- [ ] New feature
- [ ] Improvement
- [ ] Refactor
- [ ] Documentation update
- [ ] Breaking change

## Checklist
<!-- Check all that apply. -->
- [ ] I have tested the code locally
- [ ] I have added necessary documentation
- [ ] I have added relevant unit/integration tests
- [ ] I have reviewed my changes
- [ ] The code follows the project’s style guidelines


## Screenshots / Recordings
<!-- Add screenshots or recordings if applicable. -->
[Screencast from 2026-07-10 17-18-11.webm](https://github.com/user-attachments/assets/585ed7c3-2dab-485b-aeb7-e0d8d5209e03)

## Additional Notes
<!-- Any extra information you want the reviewers to know -->

### After Merging

- Notify QA (#\_ready_for_qa)
- Update JIRA tickets
- Github actions build verified
