### PR TITLE
fix(demo): block redirect for blocked email domains

### DIFF
--- a/src/components/common/HubspotForm/HubspotForm.tsx
+++ b/src/components/common/HubspotForm/HubspotForm.tsx
@@ -68,7 +68,9 @@ const HubSpotForm: React.FC<HubSpotFormProps> = ({
         ? fields.find((f: any) => f?.name === "email")?.value
         : fields?.email;
       if (email) emailRef.current = String(email).trim();
-      if (d.eventName === "onFormSubmit") startRedirect(emailRef.current);
+      // Only start the redirect after HubSpot confirms submission succeeded
+      // (i.e. passed validation including blocked domain checks).
+      if (d.eventName === "onFormSubmitted") startRedirect(emailRef.current);
     };
     window.addEventListener("message", handler);
     return () => {
@@ -82,7 +84,7 @@ const HubSpotForm: React.FC<HubSpotFormProps> = ({
     portalId,
     formId,
     cssClass: classname,
-    // Backup email capture + start the redirect early.
+    // Capture email on submit attempt (before validation).
     onFormSubmit() {
       try {
         const scope = document.getElementById(uuid);
@@ -97,7 +99,6 @@ const HubSpotForm: React.FC<HubSpotFormProps> = ({
       } catch {
         /* keep any value already captured via the message event */
       }
-      startRedirect(emailRef.current);
     },
     async onFormSubmitted() {
       try {
@@ -106,7 +107,10 @@ const HubSpotForm: React.FC<HubSpotFormProps> = ({
           return;
         }
         setSubmitting(true);
-        // Await the decision started on submit (resolve fresh if needed).
+        // Start redirect decision now (post-validation, so blocked domains
+        // never reach this point).
+        startRedirect(emailRef.current);
+        // Await the decision.
         const path = await (redirectPromiseRef.current ??
           Promise.resolve(getRedirectPathRef.current({ email: emailRef.current })));
         navigate(path || DEFAULT_REDIRECT);


### PR DESCRIPTION
## Problem

Blocked competitor domains (e.g. `blinkrx.com`) were still being redirected after form submission. The HubSpot form has these domains in its "Email domains to block" list, but the redirect logic was firing on `onFormSubmit` (pre-validation) instead of waiting for `onFormSubmitted` (post-validation).

## Fix

- `onFormSubmit` / message event `onFormSubmit`: now only captures the email, does NOT start the redirect
- `onFormSubmitted` / message event `onFormSubmitted`: starts the redirect (only fires after HubSpot validates successfully)

This ensures blocked domains are rejected by HubSpot and never reach the redirect logic.

## Testing

- Submit with a blocked domain (e.g. `test@blinkrx.com`) → should see HubSpot's blocked domain error, no redirect
- Submit with a TAM domain (e.g. `test@abbvie.com`) → should redirect to `/demo/schedule`
- Submit with a non-TAM domain (e.g. `test@example.com`) → should redirect to `/demo/thank-you`